### PR TITLE
FEAT: 상담신청 이메일 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@eslint/eslintrc": "^3",
         "@types/navermaps": "^3.7.9",
         "@types/node": "^20",
+        "@types/nodemailer": "^6.4.17",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
@@ -867,6 +868,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "jotai": "^2.12.2",
         "next": "15.2.2",
+        "nodemailer": "^6.10.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -3628,6 +3629,15 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.0.tgz",
+      "integrity": "sha512-SQ3wZCExjeSatLE/HBaXS5vqUOQk6GtBdIIKxiFdmm01mOQZX/POJkO3SUX1wDiYcwUOJwT23scFSC9fY2H8IA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@eslint/eslintrc": "^3",
     "@types/navermaps": "^3.7.9",
     "@types/node": "^20",
+    "@types/nodemailer": "^6.4.17",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "jotai": "^2.12.2",
     "next": "15.2.2",
+    "nodemailer": "^6.10.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/src/app/(home)/_sections/ContactSection/ContactSection.tsx
+++ b/src/app/(home)/_sections/ContactSection/ContactSection.tsx
@@ -33,7 +33,17 @@ export default function ContactSection() {
               <label className={s.label} htmlFor="">
                 휴대폰
               </label>
-              <input className={s.input} type="text" name="phone" />
+              <input
+                className={s.input}
+                type="text"
+                name="phone"
+                inputMode="numeric"
+                maxLength={11}
+                onInput={(e) => {
+                  const target = e.currentTarget;
+                  target.value = target.value.replace(/\D/g, "");
+                }}
+              />
             </div>
           </div>
 

--- a/src/app/(home)/_sections/ContactSection/ContactSection.tsx
+++ b/src/app/(home)/_sections/ContactSection/ContactSection.tsx
@@ -1,60 +1,39 @@
 "use client";
 
-import { useState, ChangeEvent } from "react";
+import { FormEvent } from "react";
 import { LayoutContainer } from "@/app/(home)/_components";
 import { sendEmail } from "@/lib/actions";
 import s from "./ContactSection.module.css";
 
 export default function ContactSection() {
-  const [formData, setFormData] = useState({
-    name: "",
-    phone: "",
-    content: "",
-    agreement: false,
-  });
+  const handleFormSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
 
-  const handleChange = (
-    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    const { name, type, value } = e.target;
+    const formData = new FormData(e.currentTarget);
 
-    setFormData((prevFormData) => ({
-      ...prevFormData,
-      [name]:
-        type === "checkbox" ? (e.target as HTMLInputElement).checked : value,
-    }));
+    const result = await sendEmail(formData);
+
+    alert(result.message);
   };
 
   return (
     <section className={s.ContactSection}>
       <LayoutContainer>
         <h2 className={s.title}>상담 문의</h2>
-        <form action={sendEmail}>
+        <form onSubmit={handleFormSubmit}>
           <div className={s.InputContainer}>
             <div className={s.Input}>
               <label className={s.label} htmlFor="">
                 성함
               </label>
-              <input
-                className={s.input}
-                type="text"
-                name="name"
-                value={formData.name}
-                onChange={handleChange}
-              />
+              <input className={s.input} type="text" name="name" />
             </div>
 
             <div className={s.Input}>
               <label className={s.label} htmlFor="">
                 휴대폰
               </label>
-              <input
-                className={s.input}
-                type="text"
-                name="phone"
-                value={formData.phone}
-                onChange={handleChange}
-              />
+              <input className={s.input} type="text" name="phone" />
             </div>
           </div>
 
@@ -62,21 +41,11 @@ export default function ContactSection() {
             <label className={s.label} htmlFor="">
               문의내용
             </label>
-            <textarea
-              className={s.textarea}
-              name="content"
-              value={formData.content}
-              onChange={handleChange}
-            />
+            <textarea className={s.textarea} name="content" />
           </div>
 
           <div className={s.Checkbox}>
-            <input
-              type="checkbox"
-              name="agreement"
-              checked={formData.agreement}
-              onChange={handleChange}
-            />
+            <input type="checkbox" name="agreement" />
             <label htmlFor="">개인정보 수집 및 이용동의</label>
           </div>
 

--- a/src/app/(home)/_sections/ContactSection/ContactSection.tsx
+++ b/src/app/(home)/_sections/ContactSection/ContactSection.tsx
@@ -26,7 +26,12 @@ export default function ContactSection() {
               <label className={s.label} htmlFor="">
                 성함
               </label>
-              <input className={s.input} type="text" name="name" />
+              <input
+                className={s.input}
+                type="text"
+                name="name"
+                maxLength={30}
+              />
             </div>
 
             <div className={s.Input}>

--- a/src/app/(home)/_sections/ContactSection/ContactSection.tsx
+++ b/src/app/(home)/_sections/ContactSection/ContactSection.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, ChangeEvent, FormEvent } from "react";
+import { useState, ChangeEvent } from "react";
 import { LayoutContainer } from "@/app/(home)/_components";
+import { sendEmail } from "@/lib/actions";
 import s from "./ContactSection.module.css";
 
 export default function ContactSection() {
@@ -24,24 +25,11 @@ export default function ContactSection() {
     }));
   };
 
-  const handleForm = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    setFormData({
-      name: "",
-      phone: "",
-      content: "",
-      agreement: false,
-    });
-
-    alert("상담 신청 완료!");
-  };
-
   return (
     <section className={s.ContactSection}>
       <LayoutContainer>
         <h2 className={s.title}>상담 문의</h2>
-        <form onSubmit={handleForm}>
+        <form action={sendEmail}>
           <div className={s.InputContainer}>
             <div className={s.Input}>
               <label className={s.label} htmlFor="">

--- a/src/lib/actions/index.ts
+++ b/src/lib/actions/index.ts
@@ -1,0 +1,1 @@
+export { default as sendEmail } from "./sendEmail";

--- a/src/lib/actions/sendEmail.ts
+++ b/src/lib/actions/sendEmail.ts
@@ -1,8 +1,21 @@
 "use server";
 
+import { cookies } from "next/headers";
 import nodemailer from "nodemailer";
 
 export default async function sendEmail(formData: FormData) {
+  // 1. 이메일 상담신청 확인
+  const cookieStore = await cookies();
+  const submitted = cookieStore.get("email_submitted");
+
+  if (submitted) {
+    return {
+      success: false,
+      message: "이미 상담 신청이 완료되었습니다. 잠시 후 다시 시도해주세요.",
+    };
+  }
+
+  // 2. 유효성 검사
   const name = formData.get("name");
   const phone = formData.get("phone");
   const content = formData.get("content");
@@ -16,6 +29,7 @@ export default async function sendEmail(formData: FormData) {
     return { success: false, message: "개인정보 동의가 필요합니다" };
   }
 
+  // 3. 이메일 전송
   try {
     const transporter = nodemailer.createTransport({
       service: "Naver",
@@ -37,6 +51,14 @@ export default async function sendEmail(formData: FormData) {
              <p><b>연락처:</b> ${phone}</p>
              <p><b>메시지:</b></p>
              <p>${content}</p>`,
+    });
+
+    // 4. 이메일 전송 성공 시에 연속전송 방지 쿠키 생성
+    cookieStore.set({
+      name: "email_submitted",
+      value: "true",
+      maxAge: 300, // 5분
+      path: "/",
     });
 
     return { success: true, message: "상담신청이 완료됐습니다" };

--- a/src/lib/actions/sendEmail.ts
+++ b/src/lib/actions/sendEmail.ts
@@ -1,0 +1,42 @@
+"use server";
+
+import nodemailer from "nodemailer";
+
+export default async function sendEmail(formData: FormData) {
+  const name = formData.get("name");
+  const phone = formData.get("phone");
+  const content = formData.get("content");
+
+  if (!name || !phone || !content) {
+    return { error: "모든 필드를 입력하세요." };
+  }
+
+  try {
+    const transporter = nodemailer.createTransport({
+      service: "Naver",
+      host: "smtp.naver.com",
+      port: 587,
+      secure: false,
+      auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASSWORD,
+      },
+    });
+
+    await transporter.sendMail({
+      from: process.env.EMAIL_USER,
+      to: process.env.EMAIL_TO,
+      subject: `상담 신청: ${name}`,
+      text: `이름: ${name}\n연락처: ${phone}\n메시지:\n${content}`,
+      html: `<p><b>이름:</b> ${name}</p>
+             <p><b>연락처:</b> ${phone}</p>
+             <p><b>메시지:</b></p>
+             <p>${content}</p>`,
+    });
+
+    return { success: "이메일이 성공적으로 전송되었습니다!" };
+  } catch (error) {
+    console.error("이메일 전송 오류:", error);
+    return { error: "이메일 전송 실패" };
+  }
+}

--- a/src/lib/actions/sendEmail.ts
+++ b/src/lib/actions/sendEmail.ts
@@ -8,7 +8,8 @@ export default async function sendEmail(formData: FormData) {
   const content = formData.get("content");
 
   if (!name || !phone || !content) {
-    return { error: "모든 필드를 입력하세요." };
+    console.log("🚨 오류: 모든 필드를 입력하세요.");
+    return;
   }
 
   try {
@@ -34,9 +35,10 @@ export default async function sendEmail(formData: FormData) {
              <p>${content}</p>`,
     });
 
-    return { success: "이메일이 성공적으로 전송되었습니다!" };
+    console.log("✅ 이메일이 성공적으로 전송되었습니다!");
+    return;
   } catch (error) {
     console.error("이메일 전송 오류:", error);
-    return { error: "이메일 전송 실패" };
+    return;
   }
 }

--- a/src/lib/actions/sendEmail.ts
+++ b/src/lib/actions/sendEmail.ts
@@ -6,10 +6,14 @@ export default async function sendEmail(formData: FormData) {
   const name = formData.get("name");
   const phone = formData.get("phone");
   const content = formData.get("content");
+  const agreement = formData.get("agreement") === "on";
 
   if (!name || !phone || !content) {
-    console.log("🚨 오류: 모든 필드를 입력하세요.");
-    return;
+    return { success: false, message: "비어있는 값이 있습니다" };
+  }
+
+  if (!agreement) {
+    return { success: false, message: "개인정보 동의가 필요합니다" };
   }
 
   try {
@@ -35,10 +39,12 @@ export default async function sendEmail(formData: FormData) {
              <p>${content}</p>`,
     });
 
-    console.log("✅ 이메일이 성공적으로 전송되었습니다!");
-    return;
+    return { success: true, message: "상담신청이 완료됐습니다" };
   } catch (error) {
     console.error("이메일 전송 오류:", error);
-    return;
+    return {
+      success: false,
+      message: "이메일 전송에 실패했습니다. 나중에 다시 시도해주세요.",
+    };
   }
 }


### PR DESCRIPTION
1. nodemailer를 사용해 이메일 상담신청 기능을 추가

2. 상담신청 입력할 때, 기본적인 유효성 검사 실행

3. 쿠키를 활용해 악의적인 연속 메일을 방지


Close: #3, #5, #12 